### PR TITLE
ppc64le support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o 
     && CGO_ENABLED=0 GOOS=darwin go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog-darwin . \
     && GOARM=6 GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog-armhf . \
     && GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog-arm64 . \
+    && GOARCH=ppc64le CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog-ppc64le . \
     && GOOS=windows CGO_ENABLED=0 go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog.exe .

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ fi
 docker build --no-cache --build-arg PLATFORM="-darwin" -t openfaas/of-watchdog:latest-dev-darwin . -f Dockerfile.packager
 docker build --no-cache --build-arg PLATFORM="-armhf" -t openfaas/of-watchdog:latest-dev-armhf . -f Dockerfile.packager
 docker build --no-cache --build-arg PLATFORM="-arm64" -t openfaas/of-watchdog:latest-dev-arm64 . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="-ppc64le" -t openfaas/of-watchdog:latest-dev-ppc64le . -f Dockerfile.packager
 docker build --no-cache --build-arg PLATFORM=".exe" -t openfaas/of-watchdog:latest-dev-windows . -f Dockerfile.packager
 docker build --no-cache --build-arg PLATFORM="" -t openfaas/of-watchdog:latest-dev-x86_64 . -f Dockerfile.packager
 
@@ -19,6 +20,7 @@ docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watch
 docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog-darwin ./of-watchdog-darwin
 docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog-armhf ./of-watchdog-armhf
 docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog-arm64 ./of-watchdog-arm64
+docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog-ppc64le ./of-watchdog-ppc64le
 docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog.exe ./of-watchdog.exe
 
 docker rm buildoutput

--- a/make_manifest.sh
+++ b/make_manifest.sh
@@ -8,11 +8,13 @@ docker manifest create $USR/of-watchdog:$TAG \
   $USR/of-watchdog:$TAG-x86_64 \
   $USR/of-watchdog:$TAG-armhf \
   $USR/of-watchdog:$TAG-arm64 \
+  $USR/of-watchdog:$TAG-ppc64le \
   $USR/of-watchdog:$TAG-windows
 
 docker manifest annotate $USR/of-watchdog:$TAG --arch arm $USR/of-watchdog:$TAG-darwin
 docker manifest annotate $USR/of-watchdog:$TAG --arch arm $USR/of-watchdog:$TAG-armhf
 docker manifest annotate $USR/of-watchdog:$TAG --arch arm64 $USR/of-watchdog:$TAG-arm64
+docker manifest annotate $USR/of-watchdog:$TAG --arch ppc64le $USR/of-watchdog:$TAG-ppc64le
 docker manifest annotate $USR/of-watchdog:$TAG --os windows $USR/of-watchdog:$TAG-windows
 
 docker manifest push $USR/of-watchdog:$TAG


### PR DESCRIPTION
Signed-off-by: Andrey Klyachkin <aklyachkin@gmail.com>

## Description
Support for of-watchdog on Linux/ppc64le. With these just few corrections I was able to compile it on my MacBook and use in functions on ICp/ppc64le. 

## Motivation and Context
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/faas/issues/1257

## How Has This Been Tested?
Compiled, created a new function, invoke the function

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
