### PR TITLE
fix bufio.Scanner: token too long

### DIFF
--- a/executor/logging.go
+++ b/executor/logging.go
@@ -6,19 +6,30 @@ import (
 	"log"
 )
 
+const (
+	// Size of the underlying buffer in bytes.
+	pipeReaderBufSize = bufio.MaxScanTokenSize
+)
+
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
 func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 	log.Printf("Started logging %s from function.", name)
 
-	scanner := bufio.NewScanner(pipe)
+	reader := bufio.NewReaderSize(pipe, pipeReaderBufSize)
 	logger := log.New(output, log.Prefix(), log.Flags())
 
 	go func() {
-		for scanner.Scan() {
-			logger.Printf("%s: %s", name, scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			log.Printf("Error scanning %s: %s", name, err.Error())
+		for {
+			s, err := reader.ReadString('\n')
+			if err != nil {
+				if err != io.EOF {
+					log.Printf("Error reading %s: %s", name, err.Error())
+				}
+				return
+			}
+			if len(s) > 0 {
+				logger.Printf("%s: %s", name, s)
+			}
 		}
 	}()
 }

--- a/executor/logging_test.go
+++ b/executor/logging_test.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+)
+
+//test bindLoggingPipe can process lines longer than pipeReaderBufSize
+func TestBindLoggingPipeHandlesLongLines(t *testing.T) {
+	r, w := io.Pipe()
+	defer r.Close()
+	defer w.Close()
+
+	bindLoggingPipe("stderr", r, ioutil.Discard)
+
+	done := make(chan bool)
+	go func() {
+		defer close(done)
+		lengths := []int{0, 1, 2, pipeReaderBufSize / 2, pipeReaderBufSize - 1, pipeReaderBufSize, pipeReaderBufSize + 1, pipeReaderBufSize * 2}
+		for _, l := range lengths {
+			_, err := w.Write([]byte(fmt.Sprintf("%s\n", strings.Repeat("x", l))))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Pipe writer close error: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(3 * time.Second):
+		t.Fatal("Write to pipe is hanging")
+	}
+}


### PR DESCRIPTION
## Description
Replace bufio.NewScanner by bufio.NewReaderSize as the scanner returns "token too long" error when the line is longer than 65536 bytes

## Motivation and Context
When function receives and logs long input, the "bufio.Scanner: token too long" error is logged and the request processing is stopped.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
go test was added. function built with custom image everesio/of-watchdog:0.7.7-fix is not broken any more.    

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
