### PR TITLE
Support piping long log lines from the function

### DIFF
--- a/executor/logging.go
+++ b/executor/logging.go
@@ -9,6 +9,12 @@ import (
 
 var stdLogBufferSize = 64 * 1024
 
+// logHeader creates the log prefix timestamp. This is uses the
+// format 2006/01/02 15:04:05
+var logHeader = func() []byte {
+	return []byte(time.Now().Format("2006/01/02 15:04:05"))
+}
+
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
 //
 // This implementation is adapted from https://github.com/hashicorp/go-plugin/pull/98
@@ -18,7 +24,6 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 	scanner := bufio.NewReaderSize(pipe, stdLogBufferSize)
 
 	go func() {
-		logFlags := log.Flags()
 		continuation := false
 
 		for {
@@ -34,10 +39,10 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 			if !continuation {
 				// we are not continuing a previous line, so we
 				// start the log line with the log prefix
-				output.Write(logHeader(logFlags))
+				_, _ = output.Write(logHeader())
 			}
 
-			output.Write(line)
+			_, _ = output.Write(line)
 			// the line is longer than stdLogBufferSize
 			if isPrefix || continuation {
 
@@ -45,7 +50,7 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 				// but it is the end of the actual line,
 				// so put the newline back in
 				if !isPrefix {
-					output.Write([]byte{'\n'})
+					_, _ = output.Write([]byte{'\n'})
 				}
 
 				continuation = isPrefix
@@ -54,81 +59,7 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 
 			// not a prefix or continuation, so we have written a complete line
 			// so put the newline back in
-			output.Write([]byte{'\n'})
+			_, _ = output.Write([]byte{'\n'})
 		}
 	}()
-}
-
-// logHeader copies timestamp construction from the log package `formatHeader`
-//
-// https://golang.org/src/log/log.go?s=11483:11525#L100
-//
-// this is needed to preserve backwards compatibility while also allowing us
-// to control when newlines are added to the output. By default, all print
-// statements to the logger will suffix a newline (if it is missing). This
-// prevents us from writing very long lines to the output.
-//
-// Note that this does not copy the support for the following log flags
-// * Lshortfile
-// * Llongfile
-// * Lmsgprefix
-//
-// The first two don't really make sense for the of-watchdog because we
-// don't know the file location of the log statement in the actual function
-// implementation.  The second is not implemented because it was never
-// used previously.
-//
-// Supporting the flags makes the unit testing easier.
-func logHeader(flag int) []byte {
-	buf := []byte{}
-	t := time.Now()
-	if flag&(log.Ldate|log.Ltime|log.Lmicroseconds) != 0 {
-		if flag&log.LUTC != 0 {
-			t = t.UTC()
-		}
-		if flag&log.Ldate != 0 {
-			year, month, day := t.Date()
-			itoa(&buf, year, 4)
-			buf = append(buf, '/')
-			itoa(&buf, int(month), 2)
-			buf = append(buf, '/')
-			itoa(&buf, day, 2)
-			buf = append(buf, ' ')
-		}
-		if flag&(log.Ltime|log.Lmicroseconds) != 0 {
-			hour, min, sec := t.Clock()
-			itoa(&buf, hour, 2)
-			buf = append(buf, ':')
-			itoa(&buf, min, 2)
-			buf = append(buf, ':')
-			itoa(&buf, sec, 2)
-			if flag&log.Lmicroseconds != 0 {
-				buf = append(buf, '.')
-				itoa(&buf, t.Nanosecond()/1e3, 6)
-			}
-			buf = append(buf, ' ')
-		}
-	}
-	return buf
-}
-
-// Cheap integer to fixed-width decimal ASCII. Give a negative width to avoid zero-padding.
-// Copied from the log package
-//
-// https://golang.org/src/log/log.go?s=11483:11525#L79
-//
-func itoa(buf *[]byte, i int, wid int) {
-	// Assemble decimal in reverse order.
-	var b [20]byte
-	bp := len(b) - 1
-	for i >= 10 || wid > 1 {
-		wid--
-		q := i / 10
-		b[bp] = byte('0' + i - q*10)
-		bp--
-		i = q
-	}
-	// i < 10
-	b[bp] = byte('0' + i)
-	*buf = append(*buf, b[bp:]...)
 }

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -2,23 +2,129 @@ package executor
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
+	"time"
 )
 
+var stdLogBufferSize = 64 * 1024
+
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
+//
+// This implementation is adapted from https://github.com/hashicorp/go-plugin/pull/98
 func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 	log.Printf("Started logging %s from function.", name)
 
-	scanner := bufio.NewScanner(pipe)
-	logger := log.New(output, log.Prefix(), log.Flags())
+	scanner := bufio.NewReaderSize(pipe, stdLogBufferSize)
 
 	go func() {
-		for scanner.Scan() {
-			logger.Printf("%s: %s", name, scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			log.Printf("Error scanning %s: %s", name, err.Error())
+		logFlags := log.Flags()
+		continuation := false
+
+		for {
+			line, isPrefix, err := scanner.ReadLine()
+			switch {
+			case err == io.EOF:
+				return
+			case err != nil:
+				log.Printf("Error scanning %s: %s", name, err.Error())
+				return
+			}
+
+			fmt.Println(isPrefix, string(line))
+
+			if !continuation {
+				// we are not continuing a previous line, so we
+				// start the log line with the log prefix
+				output.Write(logHeader(logFlags))
+			}
+
+			output.Write(line)
+			// the line is longer than stdLogBufferSize
+			if isPrefix || continuation {
+
+				// we are continuing a long log line,
+				// but it is the end of the actual line,
+				// so put the newline back in
+				if !isPrefix {
+					output.Write([]byte{'\n'})
+				}
+
+				continuation = isPrefix
+				continue
+			}
+
+			// not a prefix or continuation, so we have written a complete line
+			// so put the newline back in
+			output.Write([]byte{'\n'})
 		}
 	}()
+}
+
+// logHeader copies timestamp construction from the log package `formatHeader`
+// this is needed to preserve backwards compatibility while also allowing us
+// to control when newlines are added to the output. By default, all print
+// statements to the logger will suffix a newline (if it is missing). This
+// prevents us from writing very long lines to the output.
+//
+// Note that this does not copy the support for the following log flags
+// * Lshortfile
+// * Llongfile
+// * Lmsgprefix
+//
+// The first two don't really make sense for the of-watchdog because we
+// don't know the file location of the log statement in the actual function
+// implementation.  The second is not implemented because it was never
+// used previously.
+//
+// Supporting the flags makes the unit testing easier.
+func logHeader(flag int) []byte {
+	buf := []byte{}
+	t := time.Now()
+	if flag&(log.Ldate|log.Ltime|log.Lmicroseconds) != 0 {
+		if flag&log.LUTC != 0 {
+			t = t.UTC()
+		}
+		if flag&log.Ldate != 0 {
+			year, month, day := t.Date()
+			itoa(&buf, year, 4)
+			buf = append(buf, '/')
+			itoa(&buf, int(month), 2)
+			buf = append(buf, '/')
+			itoa(&buf, day, 2)
+			buf = append(buf, ' ')
+		}
+		if flag&(log.Ltime|log.Lmicroseconds) != 0 {
+			hour, min, sec := t.Clock()
+			itoa(&buf, hour, 2)
+			buf = append(buf, ':')
+			itoa(&buf, min, 2)
+			buf = append(buf, ':')
+			itoa(&buf, sec, 2)
+			if flag&log.Lmicroseconds != 0 {
+				buf = append(buf, '.')
+				itoa(&buf, t.Nanosecond()/1e3, 6)
+			}
+			buf = append(buf, ' ')
+		}
+	}
+	return buf
+}
+
+// Cheap integer to fixed-width decimal ASCII. Give a negative width to avoid zero-padding.
+func itoa(buf *[]byte, i int, wid int) {
+	// Assemble decimal in reverse order.
+	var b [20]byte
+	bp := len(b) - 1
+	for i >= 10 || wid > 1 {
+		wid--
+		q := i / 10
+		b[bp] = byte('0' + i - q*10)
+		bp--
+		i = q
+	}
+	// i < 10
+	b[bp] = byte('0' + i)
+	*buf = append(*buf, b[bp:]...)
 }

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"log"
 	"time"
@@ -31,8 +30,6 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 				log.Printf("Error scanning %s: %s", name, err.Error())
 				return
 			}
-
-			fmt.Println(isPrefix, string(line))
 
 			if !continuation {
 				// we are not continuing a previous line, so we

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -60,6 +60,9 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 }
 
 // logHeader copies timestamp construction from the log package `formatHeader`
+//
+// https://golang.org/src/log/log.go?s=11483:11525#L100
+//
 // this is needed to preserve backwards compatibility while also allowing us
 // to control when newlines are added to the output. By default, all print
 // statements to the logger will suffix a newline (if it is missing). This
@@ -110,6 +113,10 @@ func logHeader(flag int) []byte {
 }
 
 // Cheap integer to fixed-width decimal ASCII. Give a negative width to avoid zero-padding.
+// Copied from the log package
+//
+// https://golang.org/src/log/log.go?s=11483:11525#L79
+//
 func itoa(buf *[]byte, i int, wid int) {
 	// Assemble decimal in reverse order.
 	var b [20]byte

--- a/executor/logging_test.go
+++ b/executor/logging_test.go
@@ -1,0 +1,53 @@
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBindLoggingPipe(t *testing.T) {
+	// set the log timestamp prefix to just the date to make
+	// checking the output deterministic
+	log.SetFlags(log.Ldate)
+
+	// make the buffer small so that the test stays readable
+	orig := stdLogBufferSize
+	stdLogBufferSize = 32
+	defer func() {
+		stdLogBufferSize = orig
+		log.SetFlags(log.LstdFlags)
+	}()
+
+	// test several empty lines, a long line and a short line
+	msg := `
+this line is more than 32 bytes long
+
+this line is short
+`
+
+	reader := strings.NewReader(msg)
+
+	out := bytes.Buffer{}
+	bindLoggingPipe("TestFunc", reader, &out)
+
+	// give the pipe time to actually parse the logs
+	time.Sleep(1 * time.Second)
+
+	ouput := out.String()
+
+	now := time.Now().Format("2006/01/02 ")
+	expected := fmt.Sprintf(`%s
+%sthis line is more than 32 bytes long
+%s
+%sthis line is short
+`, now, now, now, now)
+
+	if ouput != expected {
+		t.Fatalf("incorrect log output: expected \n%q, got \n%q", expected, ouput)
+	}
+
+}

--- a/executor/logging_test.go
+++ b/executor/logging_test.go
@@ -12,7 +12,10 @@ import (
 func TestBindLoggingPipe(t *testing.T) {
 	// set the log timestamp prefix to just the date to make
 	// checking the output deterministic
-	log.SetFlags(log.Ldate)
+	now := time.Now().Format("2006/01/02 15:04:05")
+	logHeader = func() []byte {
+		return []byte(now)
+	}
 
 	// make the buffer small so that the test stays readable
 	orig := stdLogBufferSize
@@ -39,7 +42,6 @@ this line is short
 
 	ouput := out.String()
 
-	now := time.Now().Format("2006/01/02 ")
 	expected := fmt.Sprintf(`%s
 %sthis line is more than 32 bytes long
 %s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Use the bufio ReadLine method so that we can check if the the log line
  has been broken into several parts due to the internal buffering.
  This implementation has been adapted from
  https://github.com/hashicorp/go-plugin/pull/98

  The implementation also preserves the timestamp prefix and is
  fully backwards compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #100

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test has been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
