### PR TITLE
Log some additional internal messages to stderr

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +119,7 @@ func mapEnv(env []string) map[string]string {
 			value := val[sep+1:]
 			mapped[key] = value
 		} else {
-			fmt.Println("Bad environment: " + val)
+			log.Printf("Bad environment: %s" + val)
 		}
 	}
 

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -45,9 +44,9 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 			<-timer.C
 
 			log.Printf("Function was killed by ExecTimeout: %s\n", f.ExecTimeout.String())
-			killErr := cmd.Process.Kill()
-			if killErr != nil {
-				fmt.Println("Error killing function due to ExecTimeout", killErr)
+
+			if err := cmd.Process.Kill(); err != nil {
+				log.Printf("Error killing function due to ExecTimeout %s", err.Error())
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -341,7 +341,7 @@ func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 	}
 	functionInvoker.UpstreamURL = urlValue
 
-	fmt.Printf("Forking - %s %s\n", commandName, arguments)
+	log.Printf("Forking - %s %s", commandName, arguments)
 	functionInvoker.Start()
 
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Log some additional internal messages to stderr

## Motivation and Context

This change makes the watchdog log its internal messages to
stderr only - using log.Print.

Prior to the PR, there were a few instances of using fmt.Print

Addresses one point raised in #75

## How Has This Been Tested?

Tested with go build and running a test workload. The forking message used to be printed to stdout.

```
alex@alex-nuc8:~/go/src/github.com/openfaas/of-watchdog$ upstream_url="http://127.0.0.1:8003" mode=http fprocess="$HOME/go/src/github.com/alexellis/inlets-pro/bin/inlets-pro http fileserver -a --port 8003" ./of-watchdog 
2021/02/08 11:37:29 Forking - /home/alex/go/src/github.com/alexellis/inlets-pro/bin/inlets-pro [http fileserver -a --port 8003]
2021/02/08 11:37:29 Started logging stderr from function.
2021/02/08 11:37:29 Started logging stdout from function.
2021/02/08 11:37:29 OperationalMode: http
2021/02/08 11:37:29 Timeouts: read: 10s, write: 10s hard: 10s.
2021/02/08 11:37:29 Listening on port: 8080
2021/02/08 11:37:29 Writing lock-file to: /tmp/.lock
2021/02/08 11:37:29 Metrics listening on port: 8081
2021/02/08 11:37:29 stderr: 2021/02/08 11:37:29 Starting inlets PRO fileserver. Version 0.8.0-rc4 - 8e2bec5866b6a5cca12a50a4dc5d795fcae225e4
2021/02/08 11:37:29 stderr: 2021/02/08 11:37:29 Serving: /home/alex/go/src/github.com/openfaas/of-watchdog, on 127.0.0.1:8003, browsing: true, auth: false
2021/02/08 11:37:35 stderr: 2021/02/08 11:37:35 Request: localhost:8003 / [f9148891-cd56-4d3b-9565-525a6254ca2a]
2021/02/08 11:37:35 stderr: 2021/02/08 11:37:35 Sent /home/alex/go/src/github.com/openfaas/of-watchdog (4.1 kB) [f9148891-cd56-4d3b-9565-525a6254ca2a]
2021/02/08 11:37:39 stderr: 2021/02/08 11:37:39 Request: localhost:8003 /main.go [6fe88987-df2a-47d5-b66c-b96815642d4a]
2021/02/08 11:37:39 stderr: 2021/02/08 11:37:39 Sent /home/alex/go/src/github.com/openfaas/of-watchdog/main.go (10.3 kB) [6fe88987-df2a-47d5-b66c-b96815642d4a]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
