### PR TITLE
Fixed input stream in mode serializing

### DIFF
--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -118,7 +118,6 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 	done := time.Since(start)
 	log.Printf("Took %f secs", done.Seconds())
 
-	log.Printf("stdout %s", string(*functionRes))
 	return functionRes, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Michał Ślaga <github@blinder.pl>

ContentLength is optional in the HTTP header and cannot specify how much data will be copied to process.
https://golang.org/src/net/http/request.go?s=12527:12599
// The value -1 indicates that the length is unknown.

and copy stderr to logs - it will be helpful for troubleshooting with function.

## Description
Copy the req.InputReader stream to stdin in loop until EOF is reached.

## Motivation and Context
Not works on slow machines like raspberry pi

https://github.com/openfaas/of-watchdog/issues/123
- [x ] I have raised an issue to propose this change ([required]

## How Has This Been Tested?
In my case, on raspberry pi, the function always fails because of ContentLength -1

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
