### PR TITLE
Allow for very long log lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ Environmental variables:
 | `max_inflight`              | Yes          | Limit the maximum number of requests in flight |
 | `mode`                      | Yes          | The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
 | `prefix_logs`             | Yes          | When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true` |
-
+| `log_buffer_size` | The amount of bytes to read from stderr/stdout for log lines. When exceeded, the user will see an "bufio.Scanner: token too long" error. The default value is `bufio.MaxScanTokenSize` |
 
 > Note: the .lock file is implemented for health-checking, but cannot be disabled yet. You must create this file in /tmp/.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
 	"testing"
 	"time"
@@ -13,6 +14,27 @@ func TestNew(t *testing.T) {
 	defaults, _ := New([]string{})
 	if defaults.TCPPort != 8080 {
 		t.Errorf("Want TCPPort: 8080, got: %d", defaults.TCPPort)
+	}
+
+}
+
+func Test_LogBufferSize_Default(t *testing.T) {
+	env := []string{}
+
+	actual, _ := New(env)
+	want := bufio.MaxScanTokenSize
+	if actual.LogBufferSize != want {
+		t.Errorf("Want %v. got: %v", want, actual.LogBufferSize)
+	}
+}
+
+func Test_LogBufferSize_Override(t *testing.T) {
+	env := []string{"log_buffer_size=1024"}
+
+	actual, _ := New(env)
+	want := 1024
+	if actual.LogBufferSize != want {
+		t.Errorf("Want %v. got: %v", want, actual.LogBufferSize)
 	}
 }
 

--- a/executor/forking_runner.go
+++ b/executor/forking_runner.go
@@ -29,8 +29,9 @@ type FunctionRequest struct {
 
 // ForkFunctionRunner forks a process for each invocation
 type ForkFunctionRunner struct {
-	ExecTimeout time.Duration
-	LogPrefix   bool
+	ExecTimeout   time.Duration
+	LogPrefix     bool
+	LogBufferSize int
 }
 
 // Run run a fork for each invocation
@@ -69,7 +70,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Prints stderr to console and is picked up by container logging driver.
-	bindLoggingPipe("stderr", errPipe, os.Stderr, f.LogPrefix)
+	bindLoggingPipe("stderr", errPipe, os.Stderr, f.LogPrefix, f.LogBufferSize)
 
 	startErr := cmd.Start()
 

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -34,6 +34,7 @@ type HTTPFunctionRunner struct {
 	UpstreamURL    *url.URL
 	BufferHTTPBody bool
 	LogPrefix      bool
+	LogBufferSize  int
 }
 
 // Start forks the process used for processing incoming requests
@@ -57,8 +58,8 @@ func (f *HTTPFunctionRunner) Start() error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Logs lines from stderr and stdout to the stderr and stdout of this process
-	bindLoggingPipe("stderr", errPipe, os.Stderr, f.LogPrefix)
-	bindLoggingPipe("stdout", f.StdoutPipe, os.Stdout, f.LogPrefix)
+	bindLoggingPipe("stderr", errPipe, os.Stderr, f.LogPrefix, f.LogBufferSize)
+	bindLoggingPipe("stdout", f.StdoutPipe, os.Stdout, f.LogPrefix, f.LogBufferSize)
 
 	f.Client = makeProxyClient(f.ExecTimeout)
 

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -10,10 +10,17 @@ import (
 )
 
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
-func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bool) {
+//
+func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bool, maxBufferSize int) {
 	log.Printf("Started logging: %s from function.", name)
 
 	scanner := bufio.NewScanner(pipe)
+
+	size := bufio.MaxScanTokenSize
+
+	buffer := make([]byte, size)
+	scanner.Buffer(buffer, size)
+
 	logFlags := log.Flags()
 	prefix := log.Prefix()
 	if logPrefix == false {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Allow for very long log lines

## Motivation and Context
With this environment-variable (log_buffer_size), very large
logs can be scanned and printed out to stdio.

This was reported by RateHub (an OpenFaaS Pro) user, but has 
also been worked on several times in the past.

cc @LucasRoesler @everesio @ghostbody 

Fixes #105 #100 
Closes #99 #107

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with a 5MB JSON file and a Node.js process that
printed the value to console.log/console.error.

It worked as expected. After reducing the value to the
default, an error was returned.

```json
'use strict'
const fs = require("fs")

module.exports = async (event, context) => {

  let v=  fs.readFileSync("./function/5mb.json", "utf8")

  console.error(v)
  
  return context
    .status(200)
    .succeed(v)
}
```

```bash
http_upstream_url="http://127.0.0.1:3000" mode=http exec_timeout=30s log_buffer_size=31457280 write_timeout=30s fprocess="node index.js" read_timeout=30s write_debug=true ../../of-watchdog
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

