### PR TITLE
Silence logging from custom kubelet probes

### DIFF
--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -168,7 +169,11 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 		w.Write(bodyBytes)
 	}
 
-	log.Printf("%s %s - %s - ContentLength: %d", r.Method, r.RequestURI, res.Status, res.ContentLength)
+	// Exclude logging for health check probes from the kubelet which can spam
+	// log collection systems.
+	if !strings.HasPrefix(r.UserAgent(), "kube-probe") {
+		log.Printf("%s %s - %s - ContentLength: %d", r.Method, r.RequestURI, res.Status, res.ContentLength)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Silence logging from custom kubelet probes

## Motivation and Context

The kubelet's health check probe results in many log lines
so this checks for the prefix of "kube-probe" and silences
any logs for the http mode.

Fixes an issue reported by an OpenFaaS Pro customer.

Fixes: #130

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
go build && fprocess=cat mode=http upstream_url=http://192.168.0.15:8080 \
  ./of-watchdog

curl -i localhost:8080/healthz --user-agent "kube-probe/1.21"
```

Output before:

```bash
2022/02/20 10:42:18 GET /healthz - 200 OK - ContentLength: 0
```

After: no output.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This change is automatic and does not require a documentation change.
