### PR TITLE
Fix log formatting issue 132

### DIFF
--- a/executor/logging.go
+++ b/executor/logging.go
@@ -33,7 +33,7 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bo
 			if logPrefix {
 				logger.Printf("%s: %s", name, scanner.Text())
 			} else {
-				logger.Printf("%s", scanner.Text())
+				logger.Print(scanner.Text())
 			}
 		}
 		if err := scanner.Err(); err != nil {

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -33,7 +33,7 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bo
 			if logPrefix {
 				logger.Printf("%s: %s", name, scanner.Text())
 			} else {
-				logger.Printf(scanner.Text())
+				logger.Printf("%s", scanner.Text())
 			}
 		}
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Signed-off-by: Jeffrey C. Ollie <jeff@ocjtech.us>

Fix #132

## Description
Don't pass the scanned text from the function as the format string to fmt.Printf.

## Motivation and Context
When not prefixing the output from the function, of-watchdog would pass the output as the format string to fmt.Printf. That would mean that anything that looked like a % verb would get misinterpreted.
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
