### PR TITLE
Implement suggestions from linter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -209,11 +209,7 @@ func getInt(env map[string]string, key string, defaultValue int) int {
 }
 
 func getBool(env map[string]string, key string) bool {
-	if env[key] == "true" {
-		return true
-	}
-
-	return false
+	return env[key] == "true"
 }
 
 func getBools(env map[string]string, key ...string) bool {

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -95,7 +94,7 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 
 	var body io.Reader
 	if f.BufferHTTPBody {
-		reqBody, _ := ioutil.ReadAll(r.Body)
+		reqBody, _ := io.ReadAll(r.Body)
 		body = bytes.NewReader(reqBody)
 	} else {
 		body = r.Body
@@ -162,7 +161,7 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 	if res.Body != nil {
 		defer res.Body.Close()
 
-		bodyBytes, bodyErr := ioutil.ReadAll(res.Body)
+		bodyBytes, bodyErr := io.ReadAll(res.Body)
 		if bodyErr != nil {
 			log.Println("read body err", bodyErr)
 		}

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -10,7 +10,6 @@ import (
 )
 
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
-//
 func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bool, maxBufferSize int) {
 	log.Printf("Started logging: %s from function.", name)
 


### PR DESCRIPTION
Signed-off-by: F. Talha Altinel <talhaaltinel@hotmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have run golangci-lint v1.49.0 and used this config to eliminate false positives
```
linters-settings:
  govet:
    check-shadowing: true
    settings:
      printf:
        funcs:
          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
  funlen:
    lines: 100
    statements: 50
  goconst:
    min-len: 2
    min-occurrences: 3
    ignore-tests: true
  gocritic:
    enabled-tags:
      - diagnostic
      - experimental
      - opinionated
      - performance
      - style
    disabled-checks:
      - ifElseChain
      - whyNoLint
      - hugeParam
      - octalLiteral
  gocyclo:
    min-complexity: 20
  gomnd:
    settings:
      mnd:
        checks:
          - argument
          - case
          - condition
          - return
          - operation
          # assign is optional to enable
        ignored-numbers: "2,10,100,500,8080,0600,0660"
  lll:
    line-length: 144
  misspell:
    locale: UK
  nolintlint:
    allow-unused: false # report any unused nolint directives
    allow-leading-space: false # disable to ensure that nolint directives don't have a leading space. Default is true.)
    require-explanation: false # don't require an explanation for nolint directives
    require-specific: true # require nolint directives to be specific about which linter is being skipped

linters:
  disable-all: true
  enable:
    # ESSENTIALS AND ENABLED BY DEFAULT
    - errcheck
    - gosimple
    - govet
    - ineffassign
    - staticcheck
    - typecheck
    - unused
    # BEGINNER GO DEV SLAYER PACK
    - bodyclose
    - dogsled
    - dupl
    # - errname enable if your version is  +v1.42.0
    - exportloopref
    - forcetypeassert
    - funlen
    - gochecknoinits
    - goconst
    - gocritic
    - gocyclo
    - gofmt
    - goimports
    - revive
    - gomnd
    - gosec
    - lll
    - misspell
    - nakedret
    - nilerr
    - nolintlint
    # - paralleltest enable this to enforce table driven tests fast with t.Parallel()
    - predeclared
    - stylecheck
    - thelper
    # - tparallel enable this to enforce correct usage of t.Parallel()
    - unconvert
    - unparam

issues:
  # Excluding configuration per-path, per-linter, per-text and per-source
  exclude-rules:
    # Exclude duplicates and type assertions in the tests
    - path: _test\.go
      linters:
        - dupl
        - forcetypeassert
        - lll

    # Exclude shadowing on common Go conventions
    - linters:
        - govet
      text: "shadow: declaration of \"(err|ok|ctx)\""

    # Exclude init from main.go files
    - linters:
        - gochecknoinits
      path: main\.go

    # Exclude lll issues for long lines with go:generate
    - linters:
        - lll
      source: "^//go:generate"

    # Exclude assert for shadowing
    - linters:
        - gocritic
      text: "importShadow: shadow of imported from 'github.com/stretchr/testify/assert' package 'assert'"

    - linters:
        - gocritic
      text: "unnamedResult: consider giving a name to these results"

    - linters:
        - gosec
      text: "G204: Subprocess launched with a potential tainted input or cmd arguments"

    - linters:
        - gosec
      text: "G306: Expect WriteFile permissions to be 0600 or less"

    - linters:
        - gocritic
      text: "httpNoBody: http.NoBody should be preferred to the nil request body"

    - linters:
        - gocritic
      text: "deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop"
      path: _test\.go

    - linters:
        - gocritic
      text: "unnecessaryDefer: defer res.Body.Close() is placed just before return"
      path: _test\.go

    - linters:
        - revive
      text: "var-naming: func NewHttp should be NewHTTP"

    - linters:
        - revive
      text: "var-naming: type Http should be HTTP"

    - linters:
        - revive
      text: "errorf: should replace t.Error"
      path: _test\.go

    - linters:
        - revive
      text: "exported: type name will be used as metrics.MetricsServer by other packages, and that stutters; consider calling this Server"

    - linters:
        - gosimple
      text: "S1002: should omit comparison"

    - linters:
        - gosimple
      text: "S1038: should use t.Errorf(...)"
      path: _test\.go

    - linters:
        - nilerr
      text: "error is not nil (line 142) but it returns nil"

    - linters:
        - misspell
      text: "`serializing` is a misspelling of `serialising`"

    - linters:
        - stylecheck
      text: "ST1003: func NewHttp should be NewHTTP"

    - linters:
        - stylecheck
      text: "ST1003: type Http should be HTTP"

run:
  timeout: 4m
  skip-dirs:
    - bigquery

  skip-files:
    - lib/bad.go

rules:
  - linters:
      - dupl
    severity: info
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
raised under https://github.com/openfaas/of-watchdog/issues/55

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
no this is not tested yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code style change of linter suggestions

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional Note

I have found these errors as well but due to my limited knowledge, I didn't take action on these to not break the repository.
Would be cool to discuss it after this PR change

![image](https://user-images.githubusercontent.com/22800416/188950337-657ca983-c8f4-4a98-9279-9550a030acc2.png)







