### PR TITLE
Add support for a ready endpoint, based upon max_inflight and change timers to use a Context with a deadline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ There are several modes available for the of-watchdog which changes how it inter
 
 > A comparison of three watchdog modes. Top left - Classic Watchdog, top right: afterburn (deprecated), bottom left HTTP mode from of-watchdog.
 
+1) HTTP mode - the default and most efficient option all template authors should consider this option if the target language has a HTTP server implementation.
+2) Serializing mode - for when a HTTP server implementation doesn't exist, STDIO is read into memory then sent into a forked process.
+3) Streaming mode - as per serializing mode, however the request and response are both streamed instead of being buffered completely into memory before the function starts running.
+
 ### API
 
 Private endpoints, served by watchdog:

--- a/README.md
+++ b/README.md
@@ -6,15 +6,11 @@ Reverse proxy for HTTP microservices and STDIO
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenFaaS](https://img.shields.io/badge/openfaas-serverless-blue.svg)](https://www.openfaas.com)
 
-The `of-watchdog` implements an HTTP server listening on port 8080, and acts as a reverse proxy for running functions
-and microservices. It can be used independently, or as the entrypoint for a container with OpenFaaS.
+The `of-watchdog` implements an HTTP server listening on port 8080, and acts as a reverse proxy for running functions and microservices. It can be used independently, or as the entrypoint for a container with OpenFaaS.
 
-This version of the OpenFaaS watchdog adds support for HTTP proxying as well as STDIO, which enables re-use of memory
-and very fast serving of requests. It does not aim to replace
-the [Classic Watchdog](https://github.com/openfaas/classic-watchdog), but offers another option for those who
-need these features.
+This version of the OpenFaaS watchdog adds support for HTTP proxying as well as STDIO, which enables reuse of memory and very fast serving of requests. It does not aim to replace the [Classic Watchdog](https://github.com/openfaas/classic-watchdog), but offers another option for those who need these features.
 
-### Goals:
+### Goals
 
 * Keep function process warm for lower latency / caching / persistent connections through using HTTP
 * Enable streaming of large responses from functions, beyond the RAM or disk capacity of the container
@@ -22,30 +18,39 @@ need these features.
 
 ## Modes
 
-There are several modes available for the of-watchdog which changes how it interacts with your microservice or function
-code.
+There are several modes available for the of-watchdog which changes how it interacts with your microservice or function code.
 
 ![](https://docs.openfaas.com/architecture/watchdog-modes.png)
 
-> A comparison of three watchdog modes. Top left - Classic Watchdog, top right: afterburn (deprecated), bottom left HTTP
-> mode from of-watchdog.
+> A comparison of three watchdog modes. Top left - Classic Watchdog, top right: afterburn (deprecated), bottom left HTTP mode from of-watchdog.
+
+### API
+
+Private endpoints, served by watchdog:
+
+* `/_/health` - returns true when the process is started, or if a lock file is in use, when that file exists.
+* `/_/ready` - as per `/_/health`, but if `max_inflight` is configured to a non-zero value, and the maximum number of connections is met, it will return a 429 status
+
+Any other HTTP requests:
+
+* `/*` any other Path and HTTP verbs are sent to the function
 
 ### 1. HTTP (mode=http)
 
 #### 1.1 Status
 
-The HTTP mode is stable.
+HTTP mode is recommend for all templates where the target language has a HTTP server implementation available.
 
-See example templates:
+See a few different examples of templates, more are available via `faas-cli template store list`
 
-| Template         | HTTP framework     | Repo                                                        |
-|------------------|--------------------|-------------------------------------------------------------|
-| Node.js 12 (LTS) | Express.js         | https://github.com/openfaas/templates/                      |
-| Python 3 & 2.7   | Flask              | https://github.com/openfaas-incubator/python-flask-template |
+| Template         | HTTP framework     | Repo           |
+| ---------------- | ------------------ | ----------------------------------------------------------- |
+| Node.js 12 (LTS) | Express.js         | https://github.com/openfaas/templates/            |
+| Python 3 & 2.7   | Flask    | https://github.com/openfaas-incubator/python-flask-template |
 | Golang           | Go HTTP (stdlib)   | https://github.com/openfaas-incubator/golang-http-template  |
 | Golang           | (http.HandlerFunc) | https://github.com/openfaas-incubator/golang-http-template  |
-| Ruby             | Sinatra            | https://github.com/openfaas-incubator/ruby-http             |
-| Java 11          | Sun HTTP / Gradle  | https://github.com/openfaas/templates/                      |
+| Ruby   | Sinatra  | https://github.com/openfaas-incubator/ruby-http   |
+| Java 11          | Sun HTTP / Gradle  | https://github.com/openfaas/templates/            |
 
 Unofficial: [.NET Core / C# and Kestrel](https://github.com/burtonr/csharp-kestrel-template)
 
@@ -57,20 +62,14 @@ the container.
 Pros:
 
 * Fastest option for high concurrency and throughput
-
 * More efficient concurrency and RAM usage vs. forking model
-
 * Database connections can be persisted for the lifetime of the container
-
-* Files or models can be fetched and stored in `/tmp/` as a one-off initialization task and used for all requests after
-  that
-
-* Does not require new/custom client libraries like afterburn but makes use of a long-running daemon such as Express.js
-  for Node or Flask for Python
+* Files or models can be fetched and stored in `/tmp/` as a one-off initialization task and used for all requests after that
+* Does not require new/custom client libraries like afterburn but makes use of a long-running daemon such as Express.js for Node or Flask for Python
 
 Example usage for testing:
 
-* Forward to an NGinx container:
+* Forward to an Nginx container:
 
 ```
 $ go build ; mode=http port=8081 fprocess="docker run -p 80:80 --name nginx -t nginx" upstream_url=http://127.0.0.1:80 ./of-watchdog
@@ -85,9 +84,7 @@ $ go build ; mode=http port=8081 fprocess="node expressjs-hello-world.js" upstre
 Cons:
 
 * One more HTTP hop in the chain between the client and the function
-
 * Daemons such as express/flask/sinatra can be unpredictable when used in this way so many need additional configuration
-
 * Additional memory may be occupied between invocations vs. forking model
 
 ### 2. Serializing fork (mode=serializing)
@@ -104,31 +101,23 @@ Forks one process per request. Multi-threaded. Ideal for retro-fitting a CGI app
 
 Limited to processing files sized as per available memory.
 
-Reads entire request into memory from the HTTP request. At this point we serialize or modify if required. That is then
-written into the stdin pipe.
+Reads entire request into memory from the HTTP request. At this point we serialize or modify if required. That is then written into the stdin pipe.
 
-* Stdout pipe is read into memory and then serialized or modified if necessary before being written back to the HTTP
-  response.
-
+* Stdout pipe is read into memory and then serialized or modified if necessary before being written back to the HTTP response.
 * A static Content-type can be set ahead of time.
-
 * HTTP headers can be set even after executing the function (not implemented).
-
 * Exec timeout: supported.
 
 ### 3. Streaming fork (mode=streaming) - default.
 
-Forks a process per request and can deal with a request body larger than memory capacity - i.e. 512mb VM can process
-multiple GB of video.
+Forks a process per request and can deal with a request body larger than memory capacity - i.e. 512mb VM can process multiple GB of video.
 
 HTTP headers cannot be sent after function starts executing due to input/output being hooked-up directly to response for
 streaming efficiencies. Response code is always 200 unless there is an issue forking the process. An error mid-flight
 will have to be picked up on the client. Multi-threaded.
 
 * Input is sent back to client as soon as it's printed to stdout by the executing process.
-
 * A static Content-type can be set ahead of time.
-
 * Exec timeout: supported.
 
 ### 4. Static (mode=static)
@@ -139,8 +128,8 @@ See an example in the [Hugo blog post](https://www.openfaas.com/blog/serverless-
 
 ## Metrics
 
-| Name                          | Description                  | Type      |
-|-------------------------------|------------------------------|-----------|
+| Name      | Description        | Type      |
+| ----------------------------- | ---------------------------- | --------- |
 | http_requests_total           | Total number of requests     | Counter   |
 | http_request_duration_seconds | Duration of requests         | Histogram |
 | http_requests_in_flight       | Number of requests in-flight | Gauge     |
@@ -151,26 +140,30 @@ Environmental variables:
 
 > Note: timeouts should be specified as Golang durations i.e. `1m` or `20s`.
 
-| Option                 | Implemented                                                                                                                                                                            | Usage                                                                                                                                                                                                                                                                                                        |
-|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `function_process`     | Yes                                                                                                                                                                                    | Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Also known as "function process". Alias: `fprocess`                                                               |
-| `static_path`          | Yes                                                                                                                                                                                    | Absolute or relative path to the directory that will be served if `mode="static"`                                                                                                                                                                                                                            |
-| `read_timeout`         | Yes                                                                                                                                                                                    | HTTP timeout for reading the payload from the client caller (in seconds)                                                                                                                                                                                                                                     |
-| `write_timeout`        | Yes                                                                                                                                                                                    | HTTP timeout for writing a response body from your function (in seconds)                                                                                                                                                                                                                                     |
-| `healthcheck_interval` | Yes                                                                                                                                                                                    | Interval (in seconds) for HTTP healthcheck by container orchestrator i.e. kubelet. Used for graceful shutdowns.                                                                                                                                                                                              |
-| `exec_timeout`         | Yes                                                                                                                                                                                    | Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0.                                                                                                                                                                                                                |
-| `port`                 | Yes                                                                                                                                                                                    | Specify an alternative TCP port for testing. Default: `8080`                                                                                                                                                                                                                                                 |
-| `write_debug`          | No                                                                                                                                                                                     | Write all output, error messages, and additional information to the logs. Default is `false`.                                                                                                                                                                                                                |
-| `content_type`         | Yes                                                                                                                                                                                    | Force a specific Content-Type response for all responses - only in forking/serializing modes.                                                                                                                                                                                                                |
-| `suppress_lock`        | Yes                                                                                                                                                                                    | When set to `false` the watchdog will attempt to write a lockfile to /tmp/ for healthchecks. Default `false`                                                                                                                                                                                                 |
-| `http_upstream_url`    | Yes                                                                                                                                                                                    | `http` mode only - where to forward requests i.e. `127.0.0.1:5000`                                                                                                                                                                                                                                           |
-| `upstream_url`         | Yes                                                                                                                                                                                    | alias for `http_upstream_url`                                                                                                                                                                                                                                                                                |
-| `http_buffer_req_body` | Yes                                                                                                                                                                                    | `http` mode only - buffers request body in memory before forwarding upstream to your template's `upstream_url`. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked`, for example WSGI tends to require this setting. Default: `false`                                              |
-| `buffer_http`          | Yes                                                                                                                                                                                    | deprecated alias for `http_buffer_req_body`, will be removed in future version                                                                                                                                                                                                                               |
-| `max_inflight`         | Yes                                                                                                                                                                                    | Limit the maximum number of requests in flight                                                                                                                                                                                                                                                               |
-| `mode`                 | Yes                                                                                                                                                                                    | The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
-| `prefix_logs`          | Yes                                                                                                                                                                                    | When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true`                                                                                                                                                              |
+| Option       |Usage|
+| ---------------------- |-----|
+| `fprocess` / `function_process`     |  Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Also known as "function process".        |
+| `mode`       |  The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
+| `read_timeout`         |  HTTP timeout for reading the payload from the client caller (in seconds)          |
+| `write_timeout`        |  HTTP timeout for writing a response body from your function (in seconds)          |
+| `exec_timeout`         |  Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0.        |
+| `max_inflight`         |  Limit the maximum number of requests in flight, and return a HTTP status 429 when exceeded           |
+| `prefix_logs`          |  When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true`             |
 | `log_buffer_size`      | The amount of bytes to read from stderr/stdout for log lines. When exceeded, the user will see an "bufio.Scanner: token too long" error. The default value is `bufio.MaxScanTokenSize` |
+| `healthcheck_interval` |  Interval (in seconds) for HTTP healthcheck by container orchestrator i.e. kubelet. Used for graceful shutdowns.          |
+| `port`       |  Specify an alternative TCP port for testing. Default: `8080`            |
+| `content_type`         |  Force a specific Content-Type response for all responses - only in forking/serializing modes.        |
+| `suppress_lock`        |  When set to `false` the watchdog will attempt to write a lockfile to `/tmp/.lock` for healthchecks. Default `false`   |
+| `http_upstream_url`    |  `http` mode only - where to forward requests i.e. `127.0.0.1:5000`      |
+| `upstream_url`         |  alias for `http_upstream_url`        |
+| `http_buffer_req_body` |  `http` mode only - buffers request body in memory before forwarding upstream to your template's `upstream_url`. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked`, for example WSGI tends to require this setting. Default: `false`                |
+| `buffer_http`          |  deprecated alias for `http_buffer_req_body`, will be removed in future version    |
+| `static_path`          |  Absolute or relative path to the directory that will be served if `mode="static"` |
 
-> Note: the .lock file is implemented for health-checking, but cannot be disabled yet. You must create this file in
-> /tmp/.
+Unsupported options from the [Classic Watchdog](https://github.com/openfaas/classic-watchdog):
+
+| Option        | Usage              |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `write_debug` | In the classic watchdog, this prints the response body out to the console |
+| `read_debug` | In the classic watchdog, this prints the request body out to the console |
+| `combined_output` | In the classic watchdog, this returns STDOUT and STDERR in the function's HTTP response, when off it only returns STDOUT and prints STDERR to the logs of the watchdog |

--- a/executor/forking_runner.go
+++ b/executor/forking_runner.go
@@ -6,53 +6,33 @@ package executor
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
 	"time"
 )
 
-// FunctionRunner runs a function
-type FunctionRunner interface {
-	Run(f FunctionRequest) error
-}
-
-// FunctionRequest stores request for function execution
-type FunctionRequest struct {
-	Process     string
-	ProcessArgs []string
-	Environment []string
-
-	InputReader   io.ReadCloser
-	OutputWriter  io.Writer
-	ContentLength *int64
-}
-
-// ForkFunctionRunner forks a process for each invocation
-type ForkFunctionRunner struct {
+// StreamingFunctionRunner forks a process for each invocation
+type StreamingFunctionRunner struct {
 	ExecTimeout   time.Duration
 	LogPrefix     bool
 	LogBufferSize int
 }
 
 // Run run a fork for each invocation
-func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
+func (f *StreamingFunctionRunner) Run(req FunctionRequest) error {
 	log.Printf("Running: %s", req.Process)
 	start := time.Now()
 
 	var cmd *exec.Cmd
-	var ctx context.Context
-	if f.ExecTimeout > time.Millisecond*0 {
+	ctx := context.Background()
+	if f.ExecTimeout.Nanoseconds() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), f.ExecTimeout)
+		ctx, cancel = context.WithTimeout(ctx, f.ExecTimeout)
 		defer cancel()
-	} else {
-		ctx = context.Background()
 	}
 
 	cmd = exec.CommandContext(ctx, req.Process, req.ProcessArgs...)
-
 	if req.InputReader != nil {
 		defer req.InputReader.Close()
 		cmd.Stdin = req.InputReader

--- a/executor/function_runner.go
+++ b/executor/function_runner.go
@@ -1,0 +1,24 @@
+// Copyright (c) OpenFaaS Author(s) 2021. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package executor
+
+import (
+	"io"
+)
+
+// FunctionRunner runs a function
+type FunctionRunner interface {
+	Run(f FunctionRequest) error
+}
+
+// FunctionRequest stores request for function execution
+type FunctionRequest struct {
+	Process     string
+	ProcessArgs []string
+	Environment []string
+
+	InputReader   io.ReadCloser
+	OutputWriter  io.Writer
+	ContentLength *int64
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openfaas/of-watchdog
 go 1.18
 
 require (
-	github.com/openfaas/faas-middleware v1.0.0
+	github.com/openfaas/faas-middleware v1.1.0
 	github.com/prometheus/client_golang v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/openfaas/faas-middleware v1.0.0 h1:3w7v3sxhR55ulfDFfVHcStAKpkf06ufoZtv3pJkifvI=
 github.com/openfaas/faas-middleware v1.0.0/go.mod h1:R5CaeiPy8uo7bWTFJdJJ/9I82XLn6WeXUAjNq2a+afY=
+github.com/openfaas/faas-middleware v1.1.0 h1:i6DaUQxrg4FhMpl/to/VIEL6Aq9K/mo9EpRs0JPIqtI=
+github.com/openfaas/faas-middleware v1.1.0/go.mod h1:RgkVC/llBh+Eqb4bKxcFneB4OMnYsjUrEs7TWrRf51s=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,8 +14,8 @@ github.com/golang/protobuf/ptypes/timestamp
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 ## explicit
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/openfaas/faas-middleware v1.0.0
-## explicit
+# github.com/openfaas/faas-middleware v1.1.0
+## explicit; go 1.18
 github.com/openfaas/faas-middleware/concurrency-limiter
 # github.com/prometheus/client_golang v1.11.1
 ## explicit; go 1.13


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for a ready endpoint, based upon max_inflight and change timers to use a Context with a deadline.

## Motivation and Context
1) Ready endpoint introduced
2) Documentation updated for usage
3) Logic for timing and stopping requests that run for
too long has been switched over to use a context.

1) Currently, when a function is overloaded with too many
requests vs max_inflight i.e. 10 inflight with a limit of
2, then a 429 / retry message is returned to the caller.

Kubernetes keeps all the Pods that are overloaded in its
ready pool, so a caller like the queue-worker may have to call
many times to finally hit a pod with capacity.

By implementing a ready endpoint, the readiness check for an
individual function can be implemented, so that Kubernetes removes
it from the pool of endpoints when it exceeds its max_inflight.
It will return again when it's once again deemed to be ready.

Tested with a large amount of requests through the queue-
worker, pods were removed from the pool of endpoints as
expected.

2) The documentation was reorganise and updated for new options
and other were removed which were not relevant.

3) As per https://github.com/openfaas/of-watchdog/commit/47d5c31a5a182999ea3f904d187355023ad75955, there
were other modes which had an issue that could be resolved
by using a Context with a deadline instead of a timer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit tests on the new change to the concurrency limiter to expose a Met() method used in the new Ready endpoint.

No harm to existing functions which won't use the /_/ready path.

Then tested with some load with the queue-worker. I observed Pods being removed from the readiness count and coming back online again as expected.

This testing revealed a bug in the scale from zero logic of the gateway which was fixed here: https://github.com/openfaas/faas/pull/1753

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
