### PR TITLE
Log stderr forking mode

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2017 openfaas
+Copyright (c) 2022 OpenFaaS Author(s)
+Copyright (c) 2022 OpenFaaS Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -155,31 +155,32 @@ Environmental variables:
 
 > Note: timeouts should be specified as Golang durations i.e. `1m` or `20s`.
 
-| Option       |Usage|
-| ---------------------- |-----|
-| `fprocess` / `function_process`     |  Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Also known as "function process".        |
-| `mode`       |  The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
-| `read_timeout`         |  HTTP timeout for reading the payload from the client caller (in seconds)          |
-| `write_timeout`        |  HTTP timeout for writing a response body from your function (in seconds)          |
-| `exec_timeout`         |  Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0.        |
-| `max_inflight`         |  Limit the maximum number of requests in flight, and return a HTTP status 429 when exceeded           |
-| `prefix_logs`          |  When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true`             |
-| `log_buffer_size`      | The amount of bytes to read from stderr/stdout for log lines. When exceeded, the user will see an "bufio.Scanner: token too long" error. The default value is `bufio.MaxScanTokenSize` |
-| `healthcheck_interval` |  Interval (in seconds) for HTTP healthcheck by container orchestrator i.e. kubelet. Used for graceful shutdowns.          |
-| `port`       |  Specify an alternative TCP port for testing. Default: `8080`            |
-| `content_type`         |  Force a specific Content-Type response for all responses - only in forking/serializing modes.        |
-| `suppress_lock`        |  When set to `false` the watchdog will attempt to write a lockfile to `/tmp/.lock` for healthchecks. Default `false`   |
-| `http_upstream_url`    |  `http` mode only - where to forward requests i.e. `127.0.0.1:5000`      |
-| `upstream_url`         |  alias for `http_upstream_url`        |
-| `http_buffer_req_body` |  `http` mode only - buffers request body in memory before forwarding upstream to your template's `upstream_url`. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked`, for example WSGI tends to require this setting. Default: `false`                |
-| `buffer_http`          |  deprecated alias for `http_buffer_req_body`, will be removed in future version    |
-| `static_path`          |  Absolute or relative path to the directory that will be served if `mode="static"` |
-| `ready_path` | When non-empty, requests to `/_/ready` will invoke the function handler with this path. This can be used to provide custom readiness logic. When `max_inflight` is set, the concurrency limit is checked first before proxying the request to the function. |
+| Option                           | Usage|
+| -------------------------------- |---------------------------------------------------------------------|
+| `buffer_http`                    | (Deprecated) Alias for `http_buffer_req_body`, will be removed in future version    |
+| `content_type`                   |  Force a specific Content-Type response for all responses - only in forking/serializing modes.        |
+| `exec_timeout`                   |  Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0.        |
+| `fprocess` / `function_process`  |  Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Also known as "function process".        |
+| `healthcheck_interval`           |  Interval (in seconds) for HTTP healthcheck by container orchestrator i.e. kubelet. Used for graceful shutdowns.          |
+| `http_buffer_req_body`           |  `http` mode only - buffers request body in memory before forwarding upstream to your template's `upstream_url`. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked`, for example WSGI tends to require this setting. Default: `false`                |
+| `http_upstream_url`              |  `http` mode only - where to forward requests i.e. `http://127.0.0.1:5000`      |
+| `log_buffer_size`                | The amount of bytes to read from stderr/stdout for log lines. When exceeded, the user will see an "bufio.Scanner: token too long" error. The default value is `bufio.MaxScanTokenSize`           |
+| `max_inflight`                   |  Limit the maximum number of requests in flight, and return a HTTP status 429 when exceeded           |
+| `mode`                           |  The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
+| `port`                           |  Specify an alternative TCP port for testing. Default: `8080`            |
+| `prefix_logs`                    |  When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true`             |
+| `read_timeout`                   |  HTTP timeout for reading the payload from the client caller (in seconds)          |
+| `ready_path`                     | When non-empty, requests to `/_/ready` will invoke the function handler with this path. This can be used to provide custom readiness logic. When `max_inflight` is set, the concurrency limit is checked first before proxying the request to the function. |
+| `static_path`                    |  Absolute or relative path to the directory that will be served if `mode="static"` |
+| `suppress_lock`                  |  When set to `false` the watchdog will attempt to write a lockfile to `/tmp/.lock` for healthchecks. Default `false`   |
+| `upstream_url`                   |  Alias for `http_upstream_url`                                                          |
+| `write_timeout`                  |  HTTP timeout for writing a response body from your function (in seconds)          |
 
 Unsupported options from the [Classic Watchdog](https://github.com/openfaas/classic-watchdog):
 
-| Option        | Usage              |
-| ------------- | --------------------------------------------------------------------------------------------- |
-| `write_debug` | In the classic watchdog, this prints the response body out to the console |
-| `read_debug` | In the classic watchdog, this prints the request body out to the console |
-| `combined_output` | In the classic watchdog, this returns STDOUT and STDERR in the function's HTTP response, when off it only returns STDOUT and prints STDERR to the logs of the watchdog |
+| Option               | Usage                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `write_debug`        | In the classic watchdog, this prints the response body out to the console |
+| `read_debug`         | In the classic watchdog, this prints the request body out to the console |
+| `combined_output`    | In the classic watchdog, this returns STDOUT and STDERR in the function's HTTP response, when off it only returns STDOUT and prints STDERR to the logs of the watchdog |
+

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	units "github.com/docker/go-units"
 
@@ -98,7 +97,7 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 
 	var body io.Reader
 	if f.BufferHTTPBody {
-		reqBody, _ := ioutil.ReadAll(r.Body)
+		reqBody, _ := io.ReadAll(r.Body)
 		body = bytes.NewReader(reqBody)
 	} else {
 		body = r.Body
@@ -166,7 +165,7 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 	if res.Body != nil {
 		defer res.Body.Close()
 
-		bodyBytes, bodyErr := ioutil.ReadAll(res.Body)
+		bodyBytes, bodyErr := io.ReadAll(res.Body)
 		if bodyErr != nil {
 			log.Println("read body err", bodyErr)
 		}

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -10,7 +10,6 @@ import (
 )
 
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
-//
 func bindLoggingPipe(name string, pipe io.Reader, output io.Writer, logPrefix bool, maxBufferSize int) {
 	log.Printf("Started logging: %s from function.", name)
 

--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	units "github.com/docker/go-units"
@@ -91,7 +90,7 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 		}
 
 		var err error
-		data, err = ioutil.ReadAll(reader)
+		data, err = io.ReadAll(reader)
 
 		if err != nil {
 			return nil, err
@@ -148,7 +147,7 @@ func pipeToProcess(stdin io.WriteCloser, stdout io.Reader, data *[]byte) (*[]byt
 
 	go func(c chan error) {
 		var err error
-		result, err := ioutil.ReadAll(stdout)
+		result, err := io.ReadAll(stdout)
 		functionResult = &result
 		if err != nil {
 			c <- err

--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	units "github.com/docker/go-units"
 
@@ -21,8 +22,9 @@ import (
 
 // SerializingForkFunctionRunner forks a process for each invocation
 type SerializingForkFunctionRunner struct {
-	ExecTimeout time.Duration
-	LogPrefix   bool
+	ExecTimeout   time.Duration
+	LogPrefix     bool
+	LogBufferSize int
 }
 
 // Run run a fork for each invocation
@@ -99,10 +101,13 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 
 	stdout, _ := cmd.StdoutPipe()
 	stdin, _ := cmd.StdinPipe()
+	stderr, _ := cmd.StderrPipe()
 
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
+
+	bindLoggingPipe("stderr", stderr, os.Stderr, f.LogPrefix, f.LogBufferSize)
 
 	functionRes, errors := pipeToProcess(stdin, stdout, &data)
 	if len(errors) > 0 {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -217,14 +216,12 @@ func createLockFile() (string, error) {
 	path := filepath.Join(os.TempDir(), ".lock")
 	log.Printf("Writing lock-file to: %s\n", path)
 
-	mkdirErr := os.MkdirAll(os.TempDir(), os.ModePerm)
-	if mkdirErr != nil {
-		return path, mkdirErr
+	if err := os.MkdirAll(os.TempDir(), os.ModePerm); err != nil {
+		return path, err
 	}
 
-	writeErr := ioutil.WriteFile(path, []byte{}, 0660)
-	if writeErr != nil {
-		return path, writeErr
+	if err := os.WriteFile(path, []byte{}, 0660); err != nil {
+		return path, err
 	}
 
 	atomic.StoreInt32(&acceptingConnections, 1)

--- a/main.go
+++ b/main.go
@@ -233,8 +233,9 @@ func createLockFile() (string, error) {
 
 func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig, logPrefix bool) func(http.ResponseWriter, *http.Request) {
 	functionInvoker := executor.SerializingForkFunctionRunner{
-		ExecTimeout: watchdogConfig.ExecTimeout,
-		LogPrefix:   logPrefix,
+		ExecTimeout:   watchdogConfig.ExecTimeout,
+		LogPrefix:     logPrefix,
+		LogBufferSize: watchdogConfig.LogBufferSize,
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Log stderr forking mode

## Motivation and Context

Stream stderr to logs for streaming fork mode

This mode is not expected to be used by any customers in
production, however we received a message from a customer who
had decided to use this mode.

They reported not being able to log to stderr, I was able to
reproduce the problem and have added bindLoggingPipe to
stderr as per the other modes in the of-watchdog.

We only recommend HTTP mode for production use.

## How Has This Been Tested?
After testing with a simple Python program, the logging is
now available.

Test application:

```python
#!/bin/python3

import sys

sys.stderr.write("Test\n")
sys.stderr.flush()

print("OK\n")
```

Test command:

```
port=8083 fprocess="python3 test.py" go run .
```

Before:

No specific logs other than:

```
2023/05/31 10:02:22 GET / - 200 - ContentLength: 4B (0.0171s)
```

After:

```
2023/05/31 10:02:22 Started logging: stderr from function.
2023/05/31 10:02:22 stderr: Test
2023/05/31 10:02:22 GET / - 200 - ContentLength: 4B (0.0171s)
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
