### PR TITLE
feature: add metrics_port from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Environmental variables:
 | `http_upstream_url`              |  `http` mode only - where to forward requests i.e. `http://127.0.0.1:5000`      |
 | `log_buffer_size`                | The amount of bytes to read from stderr/stdout for log lines. When exceeded, the user will see an "bufio.Scanner: token too long" error. The default value is `bufio.MaxScanTokenSize`           |
 | `max_inflight`                   |  Limit the maximum number of requests in flight, and return a HTTP status 429 when exceeded           |
+| `metrics_port`                   |  Specify an alternative metrics port. Default: `8081`	|
 | `mode`                           |  The mode which of-watchdog operates in, Default `streaming` [see doc](#3-streaming-fork-modestreaming---default). Options are [http](#1-http-modehttp), [serialising fork](#2-serializing-fork-modeserializing), [streaming fork](#3-streaming-fork-modestreaming---default), [static](#4-static-modestatic) |
 | `port`                           |  Specify an alternative TCP port for testing. Default: `8080`            |
 | `prefix_logs`                    |  When set to `true` the watchdog will add a prefix of "Date Time" + "stderr/stdout" to every line read from the function process. Default `true`             |
@@ -183,4 +184,3 @@ Unsupported options from the [Classic Watchdog](https://github.com/openfaas/clas
 | `write_debug`        | In the classic watchdog, this prints the response body out to the console |
 | `read_debug`         | In the classic watchdog, this prints the request body out to the console |
 | `combined_output`    | In the classic watchdog, this returns STDOUT and STDERR in the function's HTTP response, when off it only returns STDOUT and prints STDERR to the logs of the watchdog |
-

--- a/config/config.go
+++ b/config/config.go
@@ -140,7 +140,7 @@ func New(env []string) (WatchdogConfig, error) {
 		SuppressLock:        getBool(envMap, "suppress_lock"),
 		UpstreamURL:         upstreamURL,
 		BufferHTTPBody:      getBools(envMap, "buffer_http", "http_buffer_req_body"),
-		MetricsPort:         8081,
+		MetricsPort:         getInt(envMap, "metrics_port", 8081),
 		MaxInflight:         getInt(envMap, "max_inflight", 0),
 		PrefixLogs:          prefixLogs,
 		LogBufferSize:       logBufferSize,


### PR DESCRIPTION
Extract metrics port from the `metrics_port` environment variable.
 

## Motivation and Context
There's no reason that the `metrics_port` is a hard-coded value.

## Types of changes
The old code isn't affected since the default value is still `8081`
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
